### PR TITLE
fix bucket not exists error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [0.4.1] - 2023/07/24
-
-### Added
+## [0.4.1] - 2023/07/25
 
 ### Changed
+
+- A ``BucketNotFound`` exception will now be thrown during
+  instantiation of either the *fluke.storage.AmazonS3File* or
+  a *fluke.storage.AmazonS3Dir* class, if the bucket provided
+  to the constructor via parameter ``bucket`` does not exist.
+  (https://github.com/manoss96/fluke/issues/42)
+
+- *fluke.exceptions.AzureBlobContainerNotFoundError* has been
+  renamed to *ContainerNotFoundError*.
+  (https://github.com/manoss96/fluke/issues/42)
 
 ### Fixed
 
@@ -14,6 +22,7 @@ All notable changes to this project will be documented in this file.
   would sometimes return fewer messages than the number of
   messages specified via parameter ``num_messages``.
   (https://github.com/manoss96/fluke/issues/40)
+
 
 ## [0.4.0] - 2023/07/24
 

--- a/fluke/_exceptions.py
+++ b/fluke/_exceptions.py
@@ -96,7 +96,28 @@ class NonStringMetadataValueError(Exception):
         super().__init__(msg)
 
 
-class AzureBlobContainerNotFoundError(Exception):
+class BucketNotFoundError(Exception):
+    '''
+    This exception is thrown whenever the user provides \
+    an Amazon S3 bucket that does not exist.
+
+    :param str bucket: The name of the bucket that \
+        was provided by the user.
+    '''
+
+    def __init__(self, bucket: str):
+        '''
+        This exception is thrown whenever the user provides \
+        an Amazon S3 bucket that does not exist.
+
+        :param str bucket: The name of the bucket that \
+            was provided by the user.
+        '''
+        msg = f'No bucket having the name "{bucket}" exists.'
+        super().__init__(msg)
+
+
+class ContainerNotFoundError(Exception):
     '''
     This exception is thrown whenever the user provides \
     an Azure blob container that does not exist.

--- a/fluke/queues.py
+++ b/fluke/queues.py
@@ -1,3 +1,11 @@
+
+
+__all__ = [
+    'AmazonSQSQueue',
+    'AzureStorageQueue',
+]
+
+
 import time as _time
 import random as _rand
 import warnings as _warn

--- a/fluke/storage.py
+++ b/fluke/storage.py
@@ -38,7 +38,7 @@ from ._exceptions import InvalidDirectoryError as _IDE
 from ._exceptions import OverwriteError as _OverwriteError
 from ._exceptions import NonStringMetadataKeyError as _NSMKE
 from ._exceptions import NonStringMetadataValueError as _NSMVE
-from ._exceptions import AzureBlobContainerNotFoundError as _ABCNFE 
+from ._exceptions import ContainerNotFoundError as _CNFE 
 
 
 class _File(_ABC):
@@ -689,6 +689,8 @@ class AmazonS3File(_CloudFile):
         any fetched data to be cached for faster subsequent \
         access.
 
+    :raises BucketNotFoundError: The specified \
+        bucket does not exist.
     :raises InvalidPathError: The provided path \
         does not exist.
     :raises InvalidFileError: The provided path \
@@ -721,6 +723,8 @@ class AmazonS3File(_CloudFile):
             any fetched data to be cached for faster subsequent \
             access. Defaults to ``False``.
 
+        :raises BucketNotFoundError: The specified \
+            bucket does not exist.
         :raises InvalidPathError: The provided path \
             does not exist.
         :raises InvalidFileError: The provided path \
@@ -820,7 +824,7 @@ class AzureBlobFile(_CloudFile):
         any fetched data to be cached for faster subsequent \
         access.
 
-    :raises AzureBlobContainerNotFoundError: The \
+    :raises ContainerNotFoundError: The \
         specified container does not exist.
     :raises InvalidPathError: The provided path \
         does not exist.
@@ -854,7 +858,7 @@ class AzureBlobFile(_CloudFile):
             any fetched data to be cached for faster subsequent \
             access. Defaults to ``False``.
 
-        :raises AzureBlobContainerNotFoundError: The \
+        :raises ContainerNotFoundError: The \
             specified container does not exist.
         :raises InvalidPathError: The provided path \
             does not exist.
@@ -888,7 +892,7 @@ class AzureBlobFile(_CloudFile):
         # Throw an exception if container does not exist.
         if not azr_handler.container_exists():
             self.close()
-            raise _ABCNFE(container)
+            raise _CNFE(container)
         
         if not azr_handler.path_exists(path=path):
             self.close()
@@ -2036,6 +2040,8 @@ class AmazonS3Dir(_CloudDir):
         in case it does not already exist, instead of an exception being \
         thrown. Defaults to ``False``.
 
+    :raises BucketNotFoundError: The specified \
+        bucket does not exist.
     :raises InvalidPathError: The provided path \
         does not exist.
 
@@ -2072,6 +2078,8 @@ class AmazonS3Dir(_CloudDir):
             in case it does not already exist, instead of an exception being \
             thrown. Defaults to ``False``.
 
+        :raises BucketNotFoundError: The specified \
+            bucket does not exist.
         :raises InvalidPathError: The provided path \
             does not exist.
 
@@ -2261,6 +2269,8 @@ class AzureBlobDir(_CloudDir):
         in case it does not already exist, instead of an exception being \
         thrown. Defaults to ``False``.
 
+    :raises ContainerNotFoundError: The \
+        specified container does not exist.
     :raises InvalidPathError: The provided path \
         does not exist.
 
@@ -2297,10 +2307,10 @@ class AzureBlobDir(_CloudDir):
             in case it does not already exist, instead of an exception being \
             thrown. Defaults to ``False``.
 
+        :raises ContainerNotFoundError: The \
+            specified container does not exist.
         :raises InvalidPathError: The provided path \
             does not exist.
-        :raises InvalidDirectoryError: The provided path \
-            does not point to a directory.
 
         :note: The provided path must not begin with \
             a separator.
@@ -2332,7 +2342,7 @@ class AzureBlobDir(_CloudDir):
         # Throw an exception if container does not exist.
         if not azr_handler.container_exists():
             self.close()
-            raise _ABCNFE(container)
+            raise _CNFE(container)
 
         # Create directory or throw an exception
         # depending on the value of "create_if_missing".


### PR DESCRIPTION
- add BucketNotFoundError exception that is thrown when a bucket does not exists.
- Rename AzureBlobContainerNotFoundError to ContainerNotFoundError
- Add tests